### PR TITLE
Minor refactoring

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -168,13 +168,18 @@ const base64urldecode = (data) => {
   return fromBase64(b64Data);
 };
 
-const sendResponse = () => {
+const sendResponse = (statusCode, body, headers) => {
   // Prevent CORS errors
   if (origin) {
     setResponseHeader('Access-Control-Allow-Origin', origin);
     setResponseHeader('Access-Control-Allow-Credentials', 'true');
     setResponseHeader('Access-Control-Allow-Headers', 'Content-Type, SP-Anonymous');
     setResponseHeader('Access-Control-Allow-Methods', 'POST, GET, OPTIONS');
+  }
+  setResponseStatus(statusCode || 200);
+  setResponseBody(body);
+  for (const key in headers) {
+    setResponseHeader(key, headers[key]);
   }
   returnResponse();
 };

--- a/template.tpl
+++ b/template.tpl
@@ -372,7 +372,9 @@ if ((data.claimGetRequests && requestPath === '/i') || requestPath === data.cust
   // Claim the requst
   claimRequest();
   log('Snowplow tracker protocol request, claimed...');
-  setResponseStatus(200);
+  let responseStatus = 200;
+  let responseBody = null;
+  let responseHeaders = {};
   
   let events;
   const requestMethod = getRequestMethod();
@@ -381,9 +383,9 @@ if ((data.claimGetRequests && requestPath === '/i') || requestPath === data.cust
     setPixelResponse();
   } else if (requestMethod === 'POST') {
     events = payloadToSnowplowEvents(getRequestBody());
-    setResponseBody("ok");
+    responseBody = 'ok';
   } else if (requestMethod === 'OPTIONS') {
-    sendResponse();
+    return sendResponse(responseStatus, responseBody, responseHeaders);
   }
   
   if (events) {
@@ -391,7 +393,7 @@ if ((data.claimGetRequests && requestPath === '/i') || requestPath === data.cust
       // Pass the event to a virtual container
       runContainer(mapSnowplowEventToTagEvent(event), () => {
         log('Tags complete, sending response...');
-        sendResponse();
+        sendResponse(responseStatus, responseBody, responseHeaders);
       });
     });
   }


### PR DESCRIPTION
* Updated `sendResponse()` to process status, header, and body
* Updated library proxy to store headers (mainly for cache reasons) and for passing them to sendResponse
* Updated tracker pings to use new sendResponse
* Removed `data.gtmOnSuccess()` references